### PR TITLE
Some superuser-only improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Caveats:
    unable to delete it. In extremely full clusters, this may result in a
    situation where you need to add capacity before you can delete objects.
 
-Future work:
+ * Requires Swift 1.12.0+, which introduced system metadata.
 
- * Allow undelete to be enabled only for particular accounts or containers
+Future work:
 
  * Move to separate account, not container, for trash. This requires Swift to
    allow cross-account COPY requests.

--- a/swift_undelete/middleware.py
+++ b/swift_undelete/middleware.py
@@ -51,14 +51,14 @@ DEFAULT_TRASH_PREFIX = ".trash-"
 DEFAULT_TRASH_LIFETIME = 86400 * 90  # 90 days expressed in seconds
 
 
-# Helper method stolen from a pending Swift change in Gerrit.
-#
-# If it ever actually lands, import and use it instead of having this
-# duplication.
-def close_if_possible(maybe_closable):
-    close_method = getattr(maybe_closable, 'close', None)
-    if callable(close_method):
-        return close_method()
+try:
+    from swift.common.request_helpers import close_if_possible
+except ImportError:
+    # Pre-1.13.0 (ref. https://github.com/openstack/swift/commit/1f67eb7)
+    def close_if_possible(maybe_closable):
+        close_method = getattr(maybe_closable, 'close', None)
+        if callable(close_method):
+            return close_method()
 
 
 def friendly_error(orig_error):

--- a/swift_undelete/middleware.py
+++ b/swift_undelete/middleware.py
@@ -176,6 +176,11 @@ class UndeleteMiddleware(object):
                 content_type="text/plain",
                 body=("Attempted to delete from a trash container, but "
                       "block_trash_deletes is enabled\n"))
+        elif self.is_trash(con) and not self.is_superuser(req.environ):
+            return swob.HTTPForbidden(
+                content_type="text/plain",
+                body=("Attempted to delete from a trash container, but "
+                      "user is not a superuser\n"))
         elif not self.should_save_copy(req.environ, con, obj):
             return self.app
 
@@ -215,6 +220,12 @@ class UndeleteMiddleware(object):
         Whether a container is a trash container or not
         """
         return con.startswith(self.trash_prefix)
+
+    def is_superuser(self, env):
+        """
+        Whether the request was made by a superuser or not
+        """
+        return bool(env.get('reseller_request'))
 
     def should_save_copy(self, env, con, obj):
         """

--- a/swift_undelete/tests/test_middleware.py
+++ b/swift_undelete/tests/test_middleware.py
@@ -349,3 +349,6 @@ class TestObjectDeletion(MiddlewareTestCase):
         status, headers, body = self.call_mware(req)
         self.assertEqual(status, "405 Method Not Allowed")
         self.assertEqual(self.app.calls, [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Two main improvements:
 1. Only superusers can DELETE objects in trash containers.
 2. Individual accounts and containers can opt out of undelete coverage. Only superusers can toggle (or even see) this flag; they may change it via a new `X-Disable-Undelete` header. Almost any value is fine; set it to "no", "false", "off", or "0" to clear the flag.

I've not yet built a new package; you can get the updated middleware installed manually with something like `cat swift_undelete/swift_undelete/middleware.py | vssh node1 -c 'sudo bash -c "cat > /usr/lib/python2.7/dist-packages/swift_undelete/middleware.py"'`

@smerritt, mind taking a look? I've not played around with middlewares much before.